### PR TITLE
Fix issue with blank nodes and sh:or

### DIFF
--- a/shacl-diagram/src/main/java/fr/sparna/rdf/shacl/diagram/PlantUmlRenderer.java
+++ b/shacl-diagram/src/main/java/fr/sparna/rdf/shacl/diagram/PlantUmlRenderer.java
@@ -172,6 +172,11 @@ public class PlantUmlRenderer {
 	private String renderAsOr(PlantUmlProperty property, String boxName, String colorArrow, String NodeShapeId) {
 		// use property local name to garantee unicity of diamond
 		String nodeshapeId = NodeShapeId.contains(":")?NodeShapeId.split(":")[1]:NodeShapeId;
+		String localName = property.getPropertyShape().getLocalName();
+		if (localName == null) {
+		    localName = property.getPropertyShape().getId().getLabelString();
+		}
+		String sNameDiamond = "diamond_" + nodeshapeId + "_" + localName.replace("-", "_");
 		String sNameDiamond = "diamond_" + nodeshapeId+"_"+property.getPropertyShape().getLocalName().replace("-", "_");
 		// diamond declaration
 		String output = "<> " + sNameDiamond + "\n";

--- a/shacl-diagram/src/main/java/fr/sparna/rdf/shacl/diagram/PlantUmlRenderer.java
+++ b/shacl-diagram/src/main/java/fr/sparna/rdf/shacl/diagram/PlantUmlRenderer.java
@@ -177,7 +177,6 @@ public class PlantUmlRenderer {
 		    localName = property.getPropertyShape().getId().getLabelString();
 		}
 		String sNameDiamond = "diamond_" + nodeshapeId + "_" + localName.replace("-", "_");
-		String sNameDiamond = "diamond_" + nodeshapeId+"_"+property.getPropertyShape().getLocalName().replace("-", "_");
 		// diamond declaration
 		String output = "<> " + sNameDiamond + "\n";
 


### PR DESCRIPTION
`getLocalName()` was returning null when the property shapes containing the `sh:or` were blank nodes. This uses the propertyshape [id ](https://www.javadoc.io/static/org.apache.jena/jena-core/2.12.0/com/hp/hpl/jena/rdf/model/Resource.html#getId()) if there is not a localName to get.

Fixes #79 