### PR TITLE
Fix left margin for content to avoid toc overlap with small screen

### DIFF
--- a/shacl-doc/src/main/resources/doc2html.xsl
+++ b/shacl-doc/src/main/resources/doc2html.xsl
@@ -344,7 +344,7 @@
 							.container {
 							    width: calc(100% - 40px);
 							    max-width: 1000px;
-							    margin-left: auto;
+							    margin-left: 300px;
 							    margin-right: auto;
 							}
 							.container {width: calc(100% - 500px);}


### PR DESCRIPTION
bug identified on https://rdafr.fr/ontologie/ when the screen is small size:

![image](https://user-images.githubusercontent.com/328244/216575771-a21e07d6-cd77-4b65-ad1d-8431d7109740.png)

the margin-left with 300px should fix the problem.

notice: I did not changed anything to the PDF générator
