### PR TITLE
Update the way `sh:targetClass` of box.getLabel() is rendered.

### DIFF
--- a/shacl-diagram/src/main/java/fr/sparna/rdf/shacl/diagram/PlantUmlBox.java
+++ b/shacl-diagram/src/main/java/fr/sparna/rdf/shacl/diagram/PlantUmlBox.java
@@ -92,7 +92,9 @@ public class PlantUmlBox {
 	
 	public String getLabel() {
 		// use the sh:targetClass if present, otherwise use the URI of the NodeShape
-		return ModelRenderingUtils.render(this.nodeShape, true)+this.getTargetClass().map(targetClass -> " ("+ModelRenderingUtils.render(targetClass, true)+")").orElse("");
+		return this.getTargetClass()
+				.map(targetClass -> ModelRenderingUtils.render(targetClass, true))
+				.orElse(ModelRenderingUtils.render(this.nodeShape, true));
 	}
 	
 	public String getPlantUmlQuotedBoxName() {


### PR DESCRIPTION
The orginal comment stated `use the sh:targetClass if present, otherwise use the URI of the NodeShape`

This commit changes the behaviour of the method that it matches the comment. Or at least the way I could interpret it.

We could also consider adding this feature as a CLI option.