### PR TITLE
fix(app): fail on an input that cannot be read instead of producing an empty result

### DIFF
--- a/shacl-play-app/src/main/java/fr/sparna/rdf/shacl/app/InputModelReader.java
+++ b/shacl-play-app/src/main/java/fr/sparna/rdf/shacl/app/InputModelReader.java
@@ -69,7 +69,14 @@ public class InputModelReader {
 			if(inputFile.exists()) {
 				if(inputFile.isDirectory()) {
 					for(File f : inputFile.listFiles()) {
-						model.add(populateModel(model, f.getAbsolutePath()));
+						// Files found by scanning a directory are read leniently: an unreadable
+						// or non-RDF file next to the data (a README, a .gitignore) is skipped
+						// with a log entry rather than failing the run.
+						try {
+							model.add(populateModel(model, f.getAbsolutePath()));
+						} catch (IllegalArgumentException skipped) {
+							log.warn("Skipping "+f.getAbsolutePath()+" : "+skipped.getMessage());
+						}
 					}
 				} else {
 					if(RDFLanguages.filenameToLang(inputFile.getName()) != null) {
@@ -87,8 +94,11 @@ public class InputModelReader {
 							// Note : getUnionModel does not include the default model, this is why we need to add it explicitely
 							model.add(d.getUnionModel());
 							model.add(d.getDefaultModel());
-						} catch (FileNotFoundException ignore) {
-							ignore.printStackTrace();
+						} catch (FileNotFoundException e) {
+							// exists() was just checked, so this means the file became
+							// unreadable between the check and the read.
+							throw new IllegalArgumentException(
+									"Cannot read input file "+inputFile.getAbsolutePath(), e);
 						}
 					} else if(inputFile.getName().endsWith("zip")) {
 						try(ZipInputStream zis = new ZipInputStream(new FileInputStream(inputFile))) {
@@ -120,7 +130,9 @@ public class InputModelReader {
 							e.printStackTrace();
 						}
 					} else {
-						log.error("Unknown RDF format for file "+inputFile.getAbsolutePath());
+						throw new IllegalArgumentException(
+								"Unknown RDF format for file "+inputFile.getAbsolutePath()
+								+". Expected an extension Jena recognises, or .zip, .xls, .xlsx.");
 					}				
 				}
 			} else if(anInput.startsWith("http")) {
@@ -128,6 +140,12 @@ public class InputModelReader {
 						model,
 						anInput
 				);
+			} else {
+				// Without this the input was skipped in silence and the command carried on
+				// with an empty model, producing an output that looks like the successful
+				// conversion of an empty ontology.
+				throw new IllegalArgumentException(
+						"Input does not exist and is not a URL : "+inputFile.getAbsolutePath());
 			}
 		} 	
 		


### PR DESCRIPTION
## Problem

`InputModelReader.populateModel` tests whether the input exists, then whether it starts with
`http`, and has **no branch for anything else**. A path that is neither an existing file nor a
URL is skipped in silence, so the command carries on with an empty model and writes an output
that is indistinguishable from the successful conversion of an empty ontology:

```console
$ shacl-play owl2shacl -i /no/such/input.ttl -o out.ttl
$ echo $?
0
$ wc -c out.ttl
720 out.ttl        # prefix declarations only
```

A typo in a path produces a plausible-looking file. The same held for an existing file whose
extension Jena does not recognise: logged as an error, then ignored.

This is not specific to `owl2shacl` — the reader is shared by **thirteen commands**.

## Change

Both cases now raise `IllegalArgumentException` naming the input, and for the format case what
was expected. The `FileNotFoundException` that was caught and printed *after* `exists()` had
already succeeded is propagated too: it can only mean the file became unreadable between the
check and the read.

**Directory inputs keep their lenient behaviour, deliberately.** Files found by scanning a
directory are skipped with a warning, so a `README` or a `.gitignore` beside the data does not
break a run. Only inputs named on the command line fail. That distinction is why the fix is in
the recursion rather than a blanket check at the top.

## Verification

With `shacl-play-app-0.12.2-onejar.jar`:

| Input | Before | After |
|---|---|---|
| `-i /no/such/input.ttl` | exit 0, 720-byte prefix-only file | **exit 1, no output file**, message naming the path |
| `-i input.ttl` (valid) | 2309 bytes | unchanged, 2309 bytes |
| `-i <dir>` containing `input.ttl` + `README.md` | 2309 bytes | unchanged, 2309 bytes, README skipped with a warning |

`shacl-validator` and `shacl-play-app` test suites pass.

## Note

Split from #344 on purpose: that PR makes the conversion *rules* an explicit input, this one
makes an unreadable *data* input fail. Neither depends on the other; they can land in either
order.
