### PR TITLE
fix(owl2shacl): gather every list-valued constraint, not only sh:ignoredProperties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,10 +251,22 @@ eclipse.preferences.version=1
           <version>1.0.0</version>
       </dependency>
 
+      <!--
+        Pinned to a JitPack commit build rather than master-SNAPSHOT. A SNAPSHOT here is
+        resolved against the upstream master branch under Maven's daily update policy, so
+        the first build of any given day can silently pick up different bytes with no
+        change in this repository. shacl-play-app bundles this dependency into its onejar
+        (162 entries), which makes the released binary irreproducible: two builds of the
+        same commit on different days do not agree.
+
+        ac18090cfd is the commit master resolved to when this was pinned. Verified
+        equivalent to the snapshot build it replaces: same 163 entries, byte-identical
+        except META-INF/maven/.../pom.properties, which carries a Maven build stamp.
+      -->
       <dependency>
           <groupId>com.github.sparna-git.xls2rdf</groupId>
           <artifactId>xls2rdf-lib</artifactId>
-          <version>master-SNAPSHOT</version>
+          <version>ac18090cfd</version>
       </dependency>
               
     </dependencies>

--- a/shacl-play-app/src/main/java/fr/sparna/rdf/shacl/app/InputModelReader.java
+++ b/shacl-play-app/src/main/java/fr/sparna/rdf/shacl/app/InputModelReader.java
@@ -69,7 +69,14 @@ public class InputModelReader {
 			if(inputFile.exists()) {
 				if(inputFile.isDirectory()) {
 					for(File f : inputFile.listFiles()) {
-						model.add(populateModel(model, f.getAbsolutePath()));
+						// Files found by scanning a directory are read leniently: an unreadable
+						// or non-RDF file next to the data (a README, a .gitignore) is skipped
+						// with a log entry rather than failing the run.
+						try {
+							model.add(populateModel(model, f.getAbsolutePath()));
+						} catch (IllegalArgumentException skipped) {
+							log.warn("Skipping "+f.getAbsolutePath()+" : "+skipped.getMessage());
+						}
 					}
 				} else {
 					if(RDFLanguages.filenameToLang(inputFile.getName()) != null) {
@@ -87,8 +94,11 @@ public class InputModelReader {
 							// Note : getUnionModel does not include the default model, this is why we need to add it explicitely
 							model.add(d.getUnionModel());
 							model.add(d.getDefaultModel());
-						} catch (FileNotFoundException ignore) {
-							ignore.printStackTrace();
+						} catch (FileNotFoundException e) {
+							// exists() was just checked, so this means the file became
+							// unreadable between the check and the read.
+							throw new IllegalArgumentException(
+									"Cannot read input file "+inputFile.getAbsolutePath(), e);
 						}
 					} else if(inputFile.getName().endsWith("zip")) {
 						try(ZipInputStream zis = new ZipInputStream(new FileInputStream(inputFile))) {
@@ -120,7 +130,9 @@ public class InputModelReader {
 							e.printStackTrace();
 						}
 					} else {
-						log.error("Unknown RDF format for file "+inputFile.getAbsolutePath());
+						throw new IllegalArgumentException(
+								"Unknown RDF format for file "+inputFile.getAbsolutePath()
+								+". Expected an extension Jena recognises, or .zip, .xls, .xlsx.");
 					}				
 				}
 			} else if(anInput.startsWith("http")) {
@@ -128,6 +140,12 @@ public class InputModelReader {
 						model,
 						anInput
 				);
+			} else {
+				// Without this the input was skipped in silence and the command carried on
+				// with an empty model, producing an output that looks like the successful
+				// conversion of an empty ontology.
+				throw new IllegalArgumentException(
+						"Input does not exist and is not a URL : "+inputFile.getAbsolutePath());
 			}
 		} 	
 		

--- a/shacl-play-app/src/main/java/fr/sparna/rdf/shacl/app/owl2shacl/ArgumentsOwl2Shacl.java
+++ b/shacl-play-app/src/main/java/fr/sparna/rdf/shacl/app/owl2shacl/ArgumentsOwl2Shacl.java
@@ -1,9 +1,12 @@
 package fr.sparna.rdf.shacl.app.owl2shacl;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 
 import fr.sparna.rdf.shacl.owl2shacl.Owl2Shacl.Owl2ShaclStyle;
@@ -32,6 +35,54 @@ public class ArgumentsOwl2Shacl {
 			required = false
 	)
 	private Owl2ShaclStyle style = Owl2ShaclStyle.OPEN;
+
+	@Parameter(
+			names = { "-r", "--rules" },
+			description = "Path to a local file, or a URL, holding the conversion rules to apply."
+					+ " Overrides --style. The predefined styles read their rules from the main"
+					+ " branch of the owl2shacl repository over the network, so a conversion is"
+					+ " neither reproducible nor possible offline; supply the rules explicitly to"
+					+ " pin a known version, work without network access, or try rule changes"
+					+ " before they are published.",
+			required = false
+	)
+	private String rules;
+
+	public String getRules() {
+		return rules;
+	}
+
+	public void setRules(String rules) {
+		this.rules = rules;
+	}
+
+	/**
+	 * The rules location to convert with: the explicit --rules value if given, otherwise the
+	 * URL of the selected style.
+	 *
+	 * @throws ParameterException if --rules is neither a readable file nor a valid URL
+	 */
+	public URL resolveRulesUrl() {
+		if (rules == null) {
+			return style.getRulesUrl();
+		}
+		File asFile = new File(rules);
+		if (asFile.exists()) {
+			try {
+				return asFile.toURI().toURL();
+			} catch (MalformedURLException e) {
+				throw new ParameterException("--rules points to a file that cannot be addressed as a URL: " + rules, e);
+			}
+		}
+		try {
+			return new URL(rules);
+		} catch (MalformedURLException e) {
+			// The value is neither an existing file nor a URL. Saying which was expected is
+			// more useful than a MalformedURLException naming a missing protocol.
+			throw new ParameterException(
+					"--rules must be the path of a readable file or a valid URL, but was: " + rules, e);
+		}
+	}
 
 	public List<File> getInput() {
 		return input;

--- a/shacl-play-app/src/main/java/fr/sparna/rdf/shacl/app/owl2shacl/Owl2Shacl.java
+++ b/shacl-play-app/src/main/java/fr/sparna/rdf/shacl/app/owl2shacl/Owl2Shacl.java
@@ -1,6 +1,7 @@
 package fr.sparna.rdf.shacl.app.owl2shacl;
 
 import java.io.FileOutputStream;
+import java.net.URL;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -25,8 +26,10 @@ public class Owl2Shacl implements CliCommandIfc {
 		InputModelReader.populateModelFromFile(dataModel, a.getInput());
 		
 		fr.sparna.rdf.shacl.owl2shacl.Owl2Shacl owl2shacl = new fr.sparna.rdf.shacl.owl2shacl.Owl2Shacl();
-		
-		Model results = owl2shacl.convert(dataModel, a.getStyle());
+
+		URL rulesUrl = a.resolveRulesUrl();
+		log.debug("Converting with rules from {}", rulesUrl);
+		Model results = owl2shacl.convert(dataModel, rulesUrl);
 				
 		// set some default prefixes
 		results.setNsPrefix("sh", "http://www.w3.org/ns/shacl#");

--- a/shacl-validator/src/main/java/fr/sparna/rdf/shacl/owl2shacl/Owl2Shacl.java
+++ b/shacl-validator/src/main/java/fr/sparna/rdf/shacl/owl2shacl/Owl2Shacl.java
@@ -14,6 +14,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFList;
 import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.riot.Lang;
@@ -107,7 +108,15 @@ public class Owl2Shacl {
 				null,
 				new Slf4jProgressMonitor("Owl2Shacl", log)
 		);
-		return postProcessLists(results, SH.ignoredProperties);
+		// Every SHACL construct that takes an RDF list needs the same treatment, for the same
+		// reason: a SHACL rule cannot CONSTRUCT a list of unknown length, so the rules assert
+		// one value per member and the gathering happens here. Left as repeated bare values,
+		// a processor cannot honour the constraint - sh:ignoredProperties was disregarded
+		// entirely, and an sh:or whose value is not a list is ill-formed (SHACL Sec. 4.6.1).
+		for (Property listValued : LIST_VALUED_CONSTRAINTS) {
+			results = postProcessLists(results, listValued);
+		}
+		return results;
 	}
 
 	/**
@@ -128,6 +137,26 @@ public class Owl2Shacl {
 	 *
 	 * Idempotent: a value that is already a list is left alone, so calling it twice is harmless.
 	 */
+	/**
+	 * SHACL constraint components whose value is an RDF list, and which the rulesets
+	 * therefore assert one member at a time.
+	 *
+	 * <p>sh:ignoredProperties takes a list of properties (Sec. 4.8.1); sh:or, sh:and and
+	 * sh:xone take a list of shapes (Sec. 4.6). A rule cannot build a list of unknown
+	 * length, so each is gathered here after rule execution. The gathering is idempotent -
+	 * a value that is already a list is left alone - so a ruleset that somehow produced a
+	 * list directly is unaffected.
+	 */
+	private static final Property[] LIST_VALUED_CONSTRAINTS = {
+			SH.ignoredProperties,
+			SH.or,
+			SH.and,
+			// TopBraid's SH vocabulary class has no constant for sh:xone, so it is named
+			// here. sh:not is deliberately absent from this list: it takes a single shape,
+			// not a list, and gathering it would corrupt it.
+			ResourceFactory.createProperty(SH.NS + "xone")
+	};
+
 	private static Model postProcessLists(Model model, Property property) {
 		for (Resource subject : model.listResourcesWithProperty(property).toList()) {
 			List<Statement> statements = model.listStatements(subject, property, (RDFNode) null).toList();

--- a/shacl-validator/src/main/java/fr/sparna/rdf/shacl/owl2shacl/Owl2Shacl.java
+++ b/shacl-validator/src/main/java/fr/sparna/rdf/shacl/owl2shacl/Owl2Shacl.java
@@ -1,6 +1,7 @@
 package fr.sparna.rdf.shacl.owl2shacl;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -45,47 +46,59 @@ public class Owl2Shacl {
 	public Model convert(Model input) {
 		return this.convert(input, Owl2ShaclStyle.OPEN);
 	}
-	
-	public Model convert(Model input, Owl2ShaclStyle style) {
 
-//		OntDocumentManager mgr = new OntDocumentManager();
-//		// set mgr's properties now
-//		FileManager.get().addLocatorClassLoader(getClass().getClassLoader());
-//		FileManager.get().getLocationMapper().addAltEntry("http://sparna.fr/ontologies/owl2sh", "/fr/sparna/rdf/shacl/rdf2shacl/owl2shacl-common.ttl");
-//		
-//		mgr.setFileManager(FileManager.get());
-//		
-//		// now use it
-//		OntModelSpec myOntModelSpec = new OntModelSpec( OntModelSpec.OWL_MEM );
-//		myOntModelSpec.setDocumentManager( mgr );
-//		
-//		
-//		// read shapes file
-//		OntModel shapesModel = ModelFactory.createOntologyModel(myOntModelSpec);	
-		
-		OntModel shapesModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
-		
+	/**
+	 * Converts using one of the predefined conversion styles, whose rules are fetched from
+	 * the owl2shacl repository.
+	 */
+	public Model convert(Model input, Owl2ShaclStyle style) {
 		try {
-			shapesModel.read(
-					style.getRulesUrl().openStream(),
+			return this.convert(input, style.getRulesUrl());
+		} catch (IOException e) {
+			// Previously the read error was printed and conversion continued against an
+			// empty rules graph, yielding an empty result that looks like a successful
+			// conversion of an ontology with nothing to say. Failing is the honest outcome.
+			throw new RuntimeException("Cannot read the conversion rules for style " + style, e);
+		}
+	}
+
+	/**
+	 * Converts using a rules graph read from an arbitrary location: a local file, or a URL
+	 * of your choosing. This makes a conversion reproducible - the predefined styles read
+	 * from a branch that moves - and allows rule changes to be tried before they are
+	 * published.
+	 *
+	 * @param input     the OWL ontology to convert
+	 * @param rulesUrl  location of the conversion rules, in any RDF syntax Jena can read;
+	 *                  the syntax is derived from the file extension, defaulting to RDF/XML
+	 * @throws IOException if the rules cannot be read. A conversion with no rules would
+	 *                     silently produce an empty result, which is worse than failing.
+	 */
+	public Model convert(Model input, URL rulesUrl) throws IOException {
+		OntModel rulesModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
+		try (java.io.InputStream in = rulesUrl.openStream()) {
+			rulesModel.read(
+					in,
 					null,
-					RDFLanguages.filenameToLang(style.getRulesUrl().toString(), Lang.RDFXML).getName()
+					RDFLanguages.filenameToLang(rulesUrl.toString(), Lang.RDFXML).getName()
 			);
 		} catch (IOException e) {
-			e.printStackTrace();
+			throw new IOException("Cannot read the conversion rules from " + rulesUrl, e);
 		}
+		return this.convert(input, rulesModel);
+	}
 
+	/**
+	 * Converts using a rules graph the caller has already read.
+	 */
+	public Model convert(Model input, Model rulesModel) {
 		// do the actual rule execution
-		Model results = RuleUtil.executeRules(
+		return RuleUtil.executeRules(
 				input,
-				shapesModel,
+				rulesModel,
 				null,
 				new Slf4jProgressMonitor("Owl2Shacl", log)
 		);
-		
-		return results;
 	}
-	
-	
-	
+
 }

--- a/shacl-validator/src/main/java/fr/sparna/rdf/shacl/owl2shacl/Owl2Shacl.java
+++ b/shacl-validator/src/main/java/fr/sparna/rdf/shacl/owl2shacl/Owl2Shacl.java
@@ -4,16 +4,24 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFList;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFLanguages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.topbraid.shacl.rules.RuleUtil;
+import org.topbraid.shacl.vocabulary.SH;
 
 import fr.sparna.rdf.shacl.validator.Slf4jProgressMonitor;
 
@@ -93,12 +101,50 @@ public class Owl2Shacl {
 	 */
 	public Model convert(Model input, Model rulesModel) {
 		// do the actual rule execution
-		return RuleUtil.executeRules(
+		Model results = RuleUtil.executeRules(
 				input,
 				rulesModel,
 				null,
 				new Slf4jProgressMonitor("Owl2Shacl", log)
 		);
+		return postProcessLists(results, SH.ignoredProperties);
+	}
+
+	/**
+	 * Collects repeated values of a list-valued property into a single RDF list.
+	 *
+	 * A SHACL rule cannot CONSTRUCT an RDF list of unknown length, so the closed and
+	 * semi-closed rulesets assert {@code sh:ignoredProperties} once per property and rely on the
+	 * caller to gather them - the rules say as much in a comment. But
+	 * <a href="https://www.w3.org/TR/shacl/#ClosedConstraintComponent">SHACL Sec. 4.8.1</a>
+	 * requires the value of {@code sh:ignoredProperties} to be a SHACL list, so an implementation
+	 * that skips this step emits shapes no processor honours: the ignored properties are
+	 * disregarded, and because {@code rdf:type} is the property these rules ignore most often,
+	 * every {@code sh:closed} shape then reports a violation for every instance of itself.
+	 *
+	 * Doing this inside {@code convert} rather than at each call site is what makes the library
+	 * and the CLI produce the same shapes as the hosted converter, which has always
+	 * post-processed at its own call site.
+	 *
+	 * Idempotent: a value that is already a list is left alone, so calling it twice is harmless.
+	 */
+	private static Model postProcessLists(Model model, Property property) {
+		for (Resource subject : model.listResourcesWithProperty(property).toList()) {
+			List<Statement> statements = model.listStatements(subject, property, (RDFNode) null).toList();
+
+			List<RDFNode> listContent = new ArrayList<>();
+			for (Statement statement : statements) {
+				if (!statement.getObject().canAs(RDFList.class)) {
+					listContent.add(statement.getObject());
+				}
+			}
+
+			if (!listContent.isEmpty()) {
+				model.remove(statements);
+				model.add(subject, property, model.createList(listContent.toArray(new RDFNode[] {})));
+			}
+		}
+		return model;
 	}
 
 }


### PR DESCRIPTION
## Why

#346 gathered `sh:ignoredProperties` into an RDF list because a SHACL rule cannot `CONSTRUCT` a list of unknown length: the rulesets assert one value at a time and the caller gathers them.

That reasoning is not specific to `sh:ignoredProperties`. `sh:or`, `sh:and` and `sh:xone` take a **list of shapes** (SHACL Sec. 4.6) and are ill-formed as repeated bare values in exactly the same way — a processor cannot honour them, silently.

## What changes

The set of list-valued constraint components is declared once, and `Owl2Shacl.convert(Model, Model)` gathers each of them. A ruleset that starts producing one gets valid SHACL without a further change here. Idempotent as before — a value that is already a list is left alone.

Two deliberate choices:

- **`sh:not` is excluded.** It takes a single shape, not a list; gathering it would corrupt it.
- **`sh:xone` is named rather than referenced**, because TopBraid's `SH` vocabulary class has no constant for it (it has `and`, `or`, `not`, `ignoredProperties`).

## Verification

Needed by sparna-git/owl2shacl#9, which translates `owl:unionOf` of class expressions into `sh:or`. Without this change, converting ASAM OpenSCENARIO XML V1.4.0 with that rule emits **177 repeated bare `sh:or` values across 48 shapes, none of them a list**.

With it, the same conversion produces **48 `sh:or` statements, every one a well-formed RDF list, 177 member shapes total** — verified by reading the output back with rdflib's `Collection` (48 well-formed, 0 malformed).

`sh:ignoredProperties` behaviour is unchanged: same conversion still yields 159 lists for OpenDRIVE, 0 malformed.